### PR TITLE
Change date formating to support macOS

### DIFF
--- a/create_dockerfile.sh
+++ b/create_dockerfile.sh
@@ -59,7 +59,7 @@ EOF
 
 dist=${1:-stretch}
 version=${2:-5.0.3}
-DATE=$(date --rfc-3339=date)
+DATE=$(date +"%Y-%m-%d")
 
 case ${dist} in
   focal|bionic|xenial|trusty|precise) base=ubuntu ;;


### PR DESCRIPTION
`date --rfc-3339=date` is not recognized by macOS as a valid format.
`date +"%Y-%m-%d"` returns the same format