### PR TITLE
Default binaries version

### DIFF
--- a/create_dockerfile.sh
+++ b/create_dockerfile.sh
@@ -58,7 +58,7 @@ EOF
 }
 
 dist=${1:-stretch}
-version=${2:-5.0.3}
+version=${2:-5.0.8}
 DATE=$(date +"%Y-%m-%d")
 
 case ${dist} in


### PR DESCRIPTION
The default binaries version for Debian Stretch (9) is 5.0.8, not 5.0.3 as stated.