### PR TITLE
add SHM_MEMORY and PKG_MEMORY as ENV support

### DIFF
--- a/create_dockerfile.sh
+++ b/create_dockerfile.sh
@@ -42,7 +42,11 @@ VOLUME /etc/kamailio
 # clean
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
-ENTRYPOINT ["kamailio", "-DD", "-E"]
+# set SHM_MEMORY and PKG_MEMORY from ENV
+ENV SHM_MEMORY=${SHM_MEMORY:-64}
+ENV PKG_MEMORY=${PKG_MEMORY:-8}
+
+ENTRYPOINT kamailio -DD -E -m $SHM_MEMORY -M $PKG_MEMORY
 EOF
 }
 


### PR DESCRIPTION
We would appreciate to modify SHM_MEMORY and PKG_MEMORY parameters externally e.g. from docker-compose or .env file. This requires to change ENTRYPOINT exec form (JSON field) to shell form, so we wouldn't need to using any external script for setting variables and starting Kamailio.  