### PR TITLE
create_dockerfile.sh: clean apt cache after tool install

### DIFF
--- a/create_dockerfile.sh
+++ b/create_dockerfile.sh
@@ -58,8 +58,9 @@ EOF
 fi
 
   cat >>"${DOCKERFILE}" <<EOF
-RUN rm -rf /var/lib/apt/lists/* && apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -qq --assume-yes gnupg wget apt-transport-https
+RUN apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -qq --assume-yes gnupg wget && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
 # kamailio repo
 RUN echo "deb ${KAM_REPO} ${dist} main" > \
   /etc/apt/sources.list.d/kamailio.list


### PR DESCRIPTION
Add `apt-get clean && rm -rf /var/lib/apt/lists/*` at the end of the gnupg/wget install `RUN` layer, and drop the redundant `rm -rf /var/lib/apt/lists/*` at the start of that same layer.

**Why:** Each `RUN` instruction creates a new layer snapshot. Without an explicit clean, the apt package cache is baked into the layer and bloats the image unnecessarily. Cleaning at the end of the same `RUN` keeps the layer lean. The pre-clean before `apt-get update` was a no-op — `apt-get update` recreates the lists regardless.

The final `apt-get install ${PKGS}` layer already does `&& apt-get clean && rm -rf /var/lib/apt/lists/*`; this brings the tool-install layer in line with the same practice.

This is one of several atomic PRs split out from #37 as requested by the maintainer.