### PR TITLE
Makefile: split dockerfile/docker-image targets, dual-tag images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,17 @@ DISTS ?= bookworm bullseye buster stretch noble jammy focal bionic
 
 VERSION ?= 6.0.0
 
-all: clean
+all: clean dockerfile docker-image
+
+dockerfile: clean
 	for i in $(DISTS) ; do \
 		./create_dockerfile.sh $$i $(VERSION); \
 	done
+
+docker-image:
+	for i in $(DISTS) ; do \
+		docker build -f $$i/Dockerfile -t kamailio-$$i:$(VERSION) -t kamailio-$(VERSION):$$i .; \
+	done
+
 clean:
-	rm -rf $(DISTS)
+	rm -rf $(DISTS)/*


### PR DESCRIPTION
Split the monolithic `all` target into two independent targets:

- **`dockerfile`** — generates the `/Dockerfile` files via `create_dockerfile.sh` (what `all` used to do)
- **`docker-image`** — builds each generated Dockerfile and tags the resulting image with both `kamailio-<dist>:<version>` and `kamailio-<version>:<dist>`

`all` now runs `clean → dockerfile → docker-image` in sequence, so the full workflow still works with a plain `make`.

The `clean` target is also tightened to `rm -rf $(DISTS)/*` (wipe contents) rather than `rm -rf $(DISTS)` (wipe directories), so repeated runs don't destroy and recreate the directory tree.

This is one of several atomic PRs split out from #37 as requested by the maintainer.