### PR TITLE
create_dockerfile.sh, Makefile: remove EOL distributions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DISTS ?= bookworm bullseye buster stretch noble jammy focal bionic
+DISTS ?= trixie bookworm bullseye noble jammy
 
 VERSION ?= 6.0.0
 

--- a/create_dockerfile.sh
+++ b/create_dockerfile.sh
@@ -89,8 +89,8 @@ EOF
 }
 
 case ${dist} in
-  resolute|noble|jammy|focal|bionic|xenial|trusty|precise) base=ubuntu ;;
-  squeeze|wheezy|jessie|stretch|buster|bullseye|bookworm|trixie) base=debian ;;
+  resolute|noble|jammy) base=ubuntu ;;
+  bullseye|bookworm|trixie) base=debian ;;
   *)
     echo "ERROR: no ${dist} base supported"
     exit 1
@@ -98,23 +98,17 @@ case ${dist} in
 esac
 
 case ${dist} in
-  squeeze|wheezy|jessie|stretch) docker_tag=${base}/eol:${dist};;
+  bullseye) docker_tag=${base}/eol:${dist};;
   *) docker_tag=${base}:${dist}
 esac
 
 case ${dist} in
-  focal|bionic|xenial|trusty|precise) apt_key=true ;;
-  squeeze|wheezy|jessie|stretch|buster) apt_key=true ;;
   *) apt_key=false ;;
 esac
 
 archived=false
 case ${dist} in
-  precise)
-    archived=true
-    RULE="RUN sed -i -e 's/archive.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list"
-    ;;
-  squeeze|wheezy|jessie|stretch)
+  bullseye)
     archived=true
     RULE="RUN sed -i -e 's/deb.debian.org/archive.debian.org/g' -e '/security.debian.org/d' -e '/${dist}-updates/d' /etc/apt/sources.list"
     ;;


### PR DESCRIPTION
Drop distributions that have reached end-of-life and are no longer receiving kamailio packages:

- **Debian**: squeeze, wheezy, jessie, stretch, buster
- **Ubuntu**: focal, bionic, xenial, trusty, precise

**Bullseye (Debian 11)** reached EOL in August 2024 and its packages have moved to `archive.debian.org`. It is kept but now treated as an archived distribution (same handling previously applied to stretch etc.): uses `debian/eol:bullseye` as the base image and rewrites `sources.list` to point at `archive.debian.org`.

The Makefile `DISTS` default list is updated to reflect currently supported distributions: `trixie bookworm bullseye noble jammy`.

This is one of several atomic PRs split out from #37 as requested by the maintainer.