### PR TITLE
create_dockerfile.sh: set trixie as default distribution

### DIFF
--- a/create_dockerfile.sh
+++ b/create_dockerfile.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-dist=${1:-bookworm}
+dist=${1:-trixie}
 version=${2:-6.0.0}
 DATE=$(date +"%Y-%m-%d")
 


### PR DESCRIPTION
Change the default distribution from `bookworm` to `trixie`.

Debian 13 (trixie) was released as stable in June 2025 and is now the current Debian stable release. Update the script default accordingly.

This is one of several atomic PRs split out from #37 as requested by the maintainer.